### PR TITLE
Disabling email verification check

### DIFF
--- a/Morphic.Server.Tests/Community/InvitationsEndpointTests.cs
+++ b/Morphic.Server.Tests/Community/InvitationsEndpointTests.cs
@@ -244,13 +244,16 @@ namespace Morphic.Server.Tests.Community
             content.Add("email", "test@morphic.org");
             request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
             response = await Client.SendAsync(request);
-            await assertJsonError(response, HttpStatusCode.BadRequest, "email_verification_required", mustContainDetails: false);
+            // While the email verification is disabled, the request should still succeed.
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            // disabled email verifiation:
+            // await assertJsonError(response, HttpStatusCode.BadRequest, "email_verification_required", mustContainDetails: false);
 
             var user = await Database.Get<User>(ManagerUserInfo.Id);
             user.EmailVerified = true;
             await Database.Save(user);
 
-            Assert.Null(JobClient.Job);
+            Assert.NotNull(JobClient.Job);
 
             // POST, success
             request = new HttpRequestMessage(HttpMethod.Post, path);

--- a/Morphic.Server/Community/InvitationsEndpoint.cs
+++ b/Morphic.Server/Community/InvitationsEndpoint.cs
@@ -69,10 +69,16 @@ namespace Morphic.Server.Community
         {
             var db = Context.GetDatabase();
             var input = await Request.ReadJson<InvitationPostRequest>();
-            if (!User.EmailVerified)
-            {
-                throw new HttpError(HttpStatusCode.BadRequest, InvitationPostError.EmailVerificationRequired);
-            }
+
+            // Removing the verification check:
+            // Currently, there is no good way for the web-client to check if the email has been verified
+            // without modifying the API (and soon the verification will be handled outside this service, so
+            // there's not much value in changing it now).
+            // if (!User.EmailVerified)
+            // {
+            //     throw new HttpError(HttpStatusCode.BadRequest, InvitationPostError.EmailVerificationRequired);
+            // }
+
             var member = await db.Get<Member>(input.MemeberId);
             if (member == null || member.CommunityId != Community.Id)
             {


### PR DESCRIPTION
Removed the email verification check when inviting another user.

The web-client doesn't know how to determine if a user's email address has been verified. Email verification will be performed elsewhere, so this is a minimal change just to get things working.