### PR TITLE
Link check fixes

### DIFF
--- a/Morphic.Server.Tests/ValidateLinkEndpointTests.cs
+++ b/Morphic.Server.Tests/ValidateLinkEndpointTests.cs
@@ -83,7 +83,7 @@ namespace Morphic.Server.Tests
             bool isGood;
             try
             {
-                await ValidateLinkEndpoint.CheckLink(url, "0.0.0.0");
+                await ValidateLinkEndpoint.CheckLink(url, "0.0.0.0", "Test/1.0" );
                 isGood = true;
             }
             catch (HttpError)
@@ -102,7 +102,7 @@ namespace Morphic.Server.Tests
             bool gotRequest = false;
             try
             {
-                await ValidateLinkEndpoint.CheckLink(url, "0.0.0.0", connectionUrl =>
+                await ValidateLinkEndpoint.CheckLink(url, "0.0.0.0", null, connectionUrl =>
                 {
                     // check the correct URL is being requested
                     Assert.Equal(new Uri(url).ToString(), connectionUrl.ToString());

--- a/Morphic.Server/Community/ValidateLinkEndpoint.cs
+++ b/Morphic.Server/Community/ValidateLinkEndpoint.cs
@@ -53,7 +53,8 @@ namespace Morphic.Server.Community
         [Method]
         public async Task Head()
         {
-            await ValidateLinkEndpoint.CheckLink(HttpUtility.UrlDecode(this.Url), this.Request.ClientIp());
+            await ValidateLinkEndpoint.CheckLink(HttpUtility.UrlDecode(this.Url), this.Request.ClientIp(),
+                this.Request.Headers["User-Agent"]);
         }
 
         /// <summary>
@@ -61,7 +62,7 @@ namespace Morphic.Server.Community
         /// </summary>
         /// <returns>Returns if the link is ok. HttpError exception if not.</returns>
         /// <exception cref="HttpError">Thrown if the link is isn't good.</exception>
-        public static async Task CheckLink(string urlString, string? clientIp, Action<Uri>? requestMaker = null)
+        public static async Task CheckLink(string urlString, string? clientIp, string? userAgent = null, Action<Uri>? requestMaker = null)
         {
             try
             {
@@ -94,6 +95,11 @@ namespace Morphic.Server.Community
                     if (!string.IsNullOrEmpty(clientIp))
                     {
                         req.Headers.Add("X-Forwarded-For", clientIp);
+                    }
+
+                    if (!string.IsNullOrEmpty(userAgent))
+                    {
+                        req.Headers.Add("User-Agent", userAgent);
                     }
 
                     req.Method = "HEAD";

--- a/Morphic.Server/Community/ValidateLinkEndpoint.cs
+++ b/Morphic.Server/Community/ValidateLinkEndpoint.cs
@@ -104,7 +104,7 @@ namespace Morphic.Server.Community
 
                     req.Method = "HEAD";
                     req.Timeout = 10000;
-                    HttpWebResponse response = (HttpWebResponse) await req.GetResponseAsync();
+                    using HttpWebResponse response = (HttpWebResponse) await req.GetResponseAsync();
                     if ((int) response.StatusCode >= 400)
                     {
                         throw new HttpError(HttpStatusCode.Gone);
@@ -117,6 +117,12 @@ namespace Morphic.Server.Community
             catch (HttpError httpError)
             {
                 throw;
+            }
+            catch (WebException webException)
+                when (webException.Response is HttpWebResponse {StatusCode: HttpStatusCode.MethodNotAllowed})
+            {
+                // 405 Method Not Allowed: it doesn't like the HEAD request, assume the link is ok otherwise it would
+                // have returned another error like 404.
             }
             catch (Exception)
             {

--- a/Morphic.Server/Community/ValidateLinkEndpoint.cs
+++ b/Morphic.Server/Community/ValidateLinkEndpoint.cs
@@ -37,6 +37,28 @@ namespace Morphic.Server.Community
     using Http;
     using Billing;
 
+    /// <summary>
+    /// This allows the web client to check if a link is working.
+    /// The browser is unable to perform this check itself, because cross-origin requests are forbidden
+    /// in https.
+    ///
+    /// This does mean the server is performing network requests on behalf of the user, so there is a potential
+    /// for trouble with accessing random resources.
+    ///
+    /// Risks:
+    /// - The server is used to access something due to IP filtering.
+    /// - An action on a remote server could be performed under the guise of the server.
+    ///
+    /// There are some limitations and mitigations:
+    /// - Only authenticated users can access this.
+    /// - This endpoint is accessed via a POST request.
+    /// - Nothing is actually read, stored, or parsed - only the HTTP response headers.
+    /// - Only normal looking URLs are accepted (http/https, non-IP, standard port)
+    /// - HEAD requests are sent, then retried with a GET (some servers don't support HEAD).
+    /// - The response from this endpoint is only success or failure (or validation error), nothing from
+    ///    the external link is provided.
+    /// - X-Forwarded-For provides the client's IP.
+    /// </summary>
     [Path("/v1/validate/link/{url}")]
     public class ValidateLinkEndpoint: Endpoint
     {

--- a/Morphic.Server/Community/ValidateLinkEndpoint.cs
+++ b/Morphic.Server/Community/ValidateLinkEndpoint.cs
@@ -142,10 +142,6 @@ namespace Morphic.Server.Community
             {
                 case 0:
                     return false;
-                case HttpStatusCode.MethodNotAllowed:
-                    // 405 Method Not Allowed: it doesn't like the HEAD request, assume the link is ok otherwise it
-                    // would have returned another error like 404.
-                    return true;
                 default:
                     return (int)statusCode < 400;
             }


### PR DESCRIPTION
* Forwards the browser's `user-agent` header to the site being checked (some sites reject requests without one)
* ~~`405 Method not allowed` status will be assumed as the link being valid.~~
* A `GET` request will be sent if `HEAD` fails.