### PR TITLE
Invitation flow: email verification

### DIFF
--- a/Morphic.Server.Tests/AuthEndpointTests.cs
+++ b/Morphic.Server.Tests/AuthEndpointTests.cs
@@ -120,6 +120,8 @@ namespace Morphic.Server.Tests
             Assert.Equal(userInfo1.FirstName, property.GetString());
             Assert.True(user.TryGetProperty("last_name", out property));
             Assert.Equal(userInfo1.LastName, property.GetString());
+            Assert.True(user.TryGetProperty("email_verified", out property));
+            Assert.Equal(userInfo1.EmailVerified, property.GetBoolean());
         }
 
         [Fact]

--- a/Morphic.Server.Tests/Community/InvitationsEndpointTests.cs
+++ b/Morphic.Server.Tests/Community/InvitationsEndpointTests.cs
@@ -244,16 +244,13 @@ namespace Morphic.Server.Tests.Community
             content.Add("email", "test@morphic.org");
             request.Content = new StringContent(JsonSerializer.Serialize(content), Encoding.UTF8, JsonMediaType);
             response = await Client.SendAsync(request);
-            // While the email verification is disabled, the request should still succeed.
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            // disabled email verifiation:
-            // await assertJsonError(response, HttpStatusCode.BadRequest, "email_verification_required", mustContainDetails: false);
+            await assertJsonError(response, HttpStatusCode.BadRequest, "email_verification_required", mustContainDetails: false);
 
             var user = await Database.Get<User>(ManagerUserInfo.Id);
             user.EmailVerified = true;
             await Database.Save(user);
 
-            Assert.NotNull(JobClient.Job);
+            Assert.Null(JobClient.Job);
 
             // POST, success
             JobClient.Jobs.Clear();

--- a/Morphic.Server.Tests/EndpointRequestTests.cs
+++ b/Morphic.Server.Tests/EndpointRequestTests.cs
@@ -167,7 +167,8 @@ namespace Morphic.Server.Tests
             public string Username { get; set; }
             public string Password { get; set; }
             public string Email { get; set; }
-            
+            public bool EmailVerified { get; set; }
+
             public string FirstName { get; set; }
             public string LastName { get; set; }
         }

--- a/Morphic.Server/Auth/EmailVerificationEmail.cs
+++ b/Morphic.Server/Auth/EmailVerificationEmail.cs
@@ -61,11 +61,9 @@ namespace Morphic.Server.Auth
                 return;
             }
             var oneTimeToken = new OneTimeToken(user.Id);
-            var verifyUri = GetFrontEndUri("/email/verify", new Dictionary<string, string>()
-            {
-                {"user_id", oneTimeToken.UserId},
-                {"token", oneTimeToken.GetUnhashedToken()}
-            });
+
+            Uri verifyUri = this.MakeEmailLink("confirm-email", oneTimeToken.UserId, oneTimeToken.GetUnhashedToken());
+
             await Db.Save(oneTimeToken);
 
             FillAttributes(user, verifyUri.ToString(), clientIp);

--- a/Morphic.Server/Auth/SignupConfirmationEmail.cs
+++ b/Morphic.Server/Auth/SignupConfirmationEmail.cs
@@ -1,0 +1,75 @@
+// Copyright 2020 Raising the Floor - International
+//
+// Licensed under the New BSD license. You may not use this file except in
+// compliance with this License.
+//
+// You may obtain a copy of the License at
+// https://github.com/GPII/universal/blob/master/LICENSE.txt
+//
+// The R&D leading to these results received funding from the:
+// * Rehabilitation Services Administration, US Dept. of Education under 
+//   grant H421A150006 (APCP)
+// * National Institute on Disability, Independent Living, and 
+//   Rehabilitation Research (NIDILRR)
+// * Administration for Independent Living & Dept. of Education under grants 
+//   H133E080022 (RERC-IT) and H133E130028/90RE5003-01-00 (UIITA-RERC)
+// * European Union's Seventh Framework Programme (FP7/2007-2013) grant 
+//   agreement nos. 289016 (Cloud4all) and 610510 (Prosperity4All)
+// * William and Flora Hewlett Foundation
+// * Ontario Ministry of Research and Innovation
+// * Canadian Foundation for Innovation
+// * Adobe Foundation
+// * Consumer Electronics Association Foundation
+
+
+namespace Morphic.Server.Auth
+{
+
+    using System;
+    using System.Threading.Tasks;
+    using Hangfire;
+    using Microsoft.Extensions.Logging;
+    using Email;
+    using Db;
+    using Users;
+
+    /// <summary>
+    /// Email sent when a new user has signed up for Morphic, after they have confirmed their email address.
+    /// </summary>
+    public class SignupConfirmationEmail : EmailJob
+    {
+        public SignupConfirmationEmail(MorphicSettings morphicSettings, EmailSettings settings,
+            ILogger<SignupConfirmationEmail> logger, Database db) : base(morphicSettings, settings, logger, db)
+        {
+            this.EmailType = EmailConstants.EmailTypes.SignupConfirmation;
+        }
+
+        [AutomaticRetry(Attempts = 20)]
+        public async Task SendEmail(string userId, string? clientIp)
+        {
+            if (this.EmailSettings.Type == EmailSettings.EmailTypeDisabled)
+            {
+                // Email shouldn't be disabled, but if it is, we want to
+                // fail this job so it retries
+                throw new Exception("Email is disabled, failing job to it will retry");
+            }
+
+            User? user = await this.Db.Get<User>(userId);
+            if (user == null)
+            {
+                throw new EmailJobException("No User");
+            }
+
+            if (user.Email.PlainText == null)
+            {
+                this.logger.LogDebug($"Sending email to user {user.Id} who doesn't have an email address");
+                return;
+            }
+
+            Uri verifyUri = this.MakeEmailLink("download", "signup");
+
+            this.FillAttributes(user, verifyUri.ToString(), clientIp);
+            await this.SendOneEmail(this.EmailType, this.Attributes);
+        }
+    }
+}

--- a/Morphic.Server/Community/InvitationAcceptEndpoint.cs
+++ b/Morphic.Server/Community/InvitationAcceptEndpoint.cs
@@ -78,6 +78,12 @@ namespace Morphic.Server.Community
             var db = Context.GetDatabase();
             Member.UserId = User.Id;
             Member.State = MemberState.Active;
+
+            if (this.User.Email.PlainText == this.Invitation.Email.PlainText)
+            {
+                this.User.EmailVerified = true;
+            }
+
             await Save(Member);
             await db.Delete(Invitation);
         }

--- a/Morphic.Server/Community/InvitationsEndpoint.cs
+++ b/Morphic.Server/Community/InvitationsEndpoint.cs
@@ -70,16 +70,10 @@ namespace Morphic.Server.Community
         {
             var db = Context.GetDatabase();
             var input = await Request.ReadJson<InvitationPostRequest>();
-
-            // Removing the verification check:
-            // Currently, there is no good way for the web-client to check if the email has been verified
-            // without modifying the API (and soon the verification will be handled outside this service, so
-            // there's not much value in changing it now).
-            // if (!User.EmailVerified)
-            // {
-            //     throw new HttpError(HttpStatusCode.BadRequest, InvitationPostError.EmailVerificationRequired);
-            // }
-
+            if (!User.EmailVerified)
+            {
+                throw new HttpError(HttpStatusCode.BadRequest, InvitationPostError.EmailVerificationRequired);
+            }
             var member = await db.Get<Member>(input.MemeberId);
             if (member == null || member.CommunityId != Community.Id)
             {

--- a/Morphic.Server/Email/EmailConstants.cs
+++ b/Morphic.Server/Email/EmailConstants.cs
@@ -11,7 +11,8 @@ namespace Morphic.Server.Email
             PasswordResetUnknownEmail = 4,
             ChangePasswordEmail = 5,
             CommunityInvitation = 6,
-            CommunityInvitationManager = 7
+            CommunityInvitationManager = 7,
+            SignupConfirmation = 8
         }
     }
 }

--- a/Morphic.Server/Email/Sendgrid.cs
+++ b/Morphic.Server/Email/Sendgrid.cs
@@ -30,6 +30,7 @@ namespace Morphic.Server.Email
         public string ChangePasswordEmailId { get; set; } = "";
         public string CommunityInvitationId { get; set; } = "";
         public string CommunityInvitationManagerId { get; set; } = "";
+        public string SignupConfirmationId { get; set; } = "";
     }
 
     public class Sendgrid : SendEmailWorker
@@ -68,6 +69,9 @@ namespace Morphic.Server.Email
                     break;
                 case EmailConstants.EmailTypes.CommunityInvitationManager:
                     emailTemplateId = emailSettings.SendGridSettings.CommunityInvitationManagerId;
+                    break;
+                case EmailConstants.EmailTypes.SignupConfirmation:
+                    emailTemplateId = emailSettings.SendGridSettings.SignupConfirmationId;
                     break;
                 case EmailConstants.EmailTypes.None:
                     throw new SendgridException("EmailType None");

--- a/Morphic.Server/Users/User.cs
+++ b/Morphic.Server/Users/User.cs
@@ -46,7 +46,7 @@ namespace Morphic.Server.Users
         public string? PreferencesId { get; set; }
         [JsonPropertyName("email")]
         public SearchableEncryptedString Email { get; set; } = new SearchableEncryptedString();
-        [JsonIgnore]
+        [JsonPropertyName("email_verified")]
         public bool EmailVerified { get; set; }
         [JsonIgnore]
         public DateTime LastAuth { get; set; }

--- a/Morphic.Server/appsettings.json
+++ b/Morphic.Server/appsettings.json
@@ -37,7 +37,8 @@
       "PasswordResetUnknownEmailId": "d-d8658c61548e4a958f41a75fc3971b5d",
       "ChangePasswordEmailId": "d-c21a156523634487b65825fcff1b9787",
       "CommunityInvitationId": "d-76045714b755443fa0a0a67abee93b05",
-      "CommunityInvitationManagerId": "d-183082e244924d94a72fd8f9b774a5ad"
+      "CommunityInvitationManagerId": "d-183082e244924d94a72fd8f9b774a5ad",
+      "SignupConfirmationId": "new"
     },
     "SendInBlueSettings": {
       "WelcomeEmailValidationId": "1",


### PR DESCRIPTION
- Enables email verification, and provides the information required by the front-end to do it.
- *Existing user accounts will now need to verify their email addresses to send invitations.*
- Send the sign-up confirmation email, which links to the download page.
- Emails addresses are automatically verified if the member signed up with the email that the invitation was sent to.

Depends on https://github.com/raisingthefloor/morphic-community-webapp/pull/192