### PR TITLE
Support for account settings page

### DIFF
--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -831,6 +831,12 @@ Get a list of communities the user belongs to.
       <td><code>Role</code></td>
       <td>Required</td>
     </tr>
+    <tr>
+      <td>&nbsp;&nbsp;&nbsp;&nbsp;<code>[i].member_id</code></td>
+      <td>The user's member id for the community</td>
+      <td><code>GUID</code></td>
+      <td>Required</td>
+    </tr>
   </tbody>
 </table>
 

--- a/Morphic.Server.Tests/Community/BarEndpointTests.cs
+++ b/Morphic.Server.Tests/Community/BarEndpointTests.cs
@@ -184,7 +184,7 @@ namespace Morphic.Server.Tests.Community
             request = new HttpRequestMessage(HttpMethod.Get, path);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", ActiveUserInfo.AuthToken);
             response = await Client.SendAsync(request);
-            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // GET, not active
             request = new HttpRequestMessage(HttpMethod.Get, path);

--- a/Morphic.Server.Tests/Community/CommunityEndpointTests.cs
+++ b/Morphic.Server.Tests/Community/CommunityEndpointTests.cs
@@ -115,7 +115,7 @@ namespace Morphic.Server.Tests.Community
             request = new HttpRequestMessage(HttpMethod.Get, path);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", ActiveUserInfo.AuthToken);
             response = await Client.SendAsync(request);
-            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // GET, not active
             request = new HttpRequestMessage(HttpMethod.Get, path);

--- a/Morphic.Server.Tests/Community/MemberEndpointTests.cs
+++ b/Morphic.Server.Tests/Community/MemberEndpointTests.cs
@@ -153,7 +153,7 @@ namespace Morphic.Server.Tests.Community
             request = new HttpRequestMessage(HttpMethod.Get, path);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", ActiveUserInfo.AuthToken);
             response = await Client.SendAsync(request);
-            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // GET, not active
             request = new HttpRequestMessage(HttpMethod.Get, path);

--- a/Morphic.Server/Community/BarEndpoint.cs
+++ b/Morphic.Server/Community/BarEndpoint.cs
@@ -55,11 +55,11 @@ namespace Morphic.Server.Community
             User = await RequireUser();
             Community = await Load<Community>(CommunityId);
             Member = await Load<Member>(m => m.UserId == User.Id && m.CommunityId == Community.Id && m.State == MemberState.Active);
-            if (Member.Role != MemberRole.Manager)
+            Bar = await Load<Bar>(Id);
+            if (Member.Role != MemberRole.Manager && this.Member.UserId != this.User.Id)
             {
                 throw new HttpError(HttpStatusCode.Forbidden);
             }
-            Bar = await Load<Bar>(Id);
             if (Bar.CommunityId != Community.Id)
             {
                 throw new HttpError(HttpStatusCode.NotFound);
@@ -80,6 +80,11 @@ namespace Morphic.Server.Community
         [Method]
         public async Task Put()
         {
+            if (Member.Role != MemberRole.Manager)
+            {
+                throw new HttpError(HttpStatusCode.Forbidden);
+            }
+
             var input = await Request.ReadJson<BarPutRequest>();
             if (Bar.Id == Community.DefaultBarId && !input.IsShared)
             {
@@ -107,6 +112,11 @@ namespace Morphic.Server.Community
         [Method]
         public async Task Delete()
         {
+            if (Member.Role != MemberRole.Manager)
+            {
+                throw new HttpError(HttpStatusCode.Forbidden);
+            }
+
             if (Bar.Id == Community.DefaultBarId)
             {
                 throw new HttpError(HttpStatusCode.BadRequest, BarDeleteError.CannotDeleteDefault);

--- a/Morphic.Server/Community/CommunityEndpoint.cs
+++ b/Morphic.Server/Community/CommunityEndpoint.cs
@@ -47,7 +47,7 @@ namespace Morphic.Server.Community
             var authenticatedUser = await RequireUser();
             Community = await Load<Community>(Id);
             Member = await Load<Member>(m => m.CommunityId == Community.Id && m.UserId == authenticatedUser.Id && m.State == MemberState.Active);
-            if (Member.Role != MemberRole.Manager){
+            if (Member.Role != MemberRole.Manager && this.Member.UserId != authenticatedUser.Id){
                 throw new HttpError(HttpStatusCode.Forbidden);
             }
         }
@@ -64,6 +64,11 @@ namespace Morphic.Server.Community
         [Method]
         public async Task Put()
         {
+            if (Member.Role != MemberRole.Manager)
+            {
+                throw new HttpError(HttpStatusCode.Forbidden);
+            }
+
             var db = Context.GetDatabase();
             var input = await Request.ReadJson<CommunityPutRequest>();
             Community.Name = input.Name;
@@ -78,6 +83,11 @@ namespace Morphic.Server.Community
 
         [Method]
         public async Task Delete(){
+            if (Member.Role != MemberRole.Manager)
+            {
+                throw new HttpError(HttpStatusCode.Forbidden);
+            }
+
             var db = Context.GetDatabase();
             await db.Delete(Community);
             await db.DeleteAll<Member>(m => m.CommunityId == Community.Id);

--- a/Morphic.Server/Community/UserCommunitiesEndpoint.cs
+++ b/Morphic.Server/Community/UserCommunitiesEndpoint.cs
@@ -72,16 +72,17 @@ namespace Morphic.Server.Community
         public async Task Get()
         {
             var collection = new UserCommunityCollection();
-            foreach (var pair in Communities){
-                if (pair.Item1.IsMemberLocked)
+            foreach ((Community community, Member member) in Communities){
+                if (community.IsMemberLocked)
                 {
                     continue;
                 }
                 collection.Communities.Add(new UserCommunityCollectionItem()
                 {
-                    Id = pair.Item1.Id,
-                    Name = pair.Item1.Name,
-                    Role = pair.Item2.Role
+                    Id = community.Id,
+                    Name = community.Name,
+                    Role = member.Role,
+                    MemberId = member.Id
                 });
             }
             await Respond(collection);
@@ -97,6 +98,9 @@ namespace Morphic.Server.Community
 
             [JsonPropertyName("role")]
             public MemberRole Role { get; set; }
+
+            [JsonPropertyName("member_id")]
+            public string MemberId { get; set; }
         }
 
         private class UserCommunityCollection


### PR DESCRIPTION
Get some extra data for the account page

* Exposes the member's ID.
* Allows a non-manager member to view their own bars and community.