### PR TITLE
Exposing coupon duration in the API

### DIFF
--- a/Morphic.Server/Billing/PromoCode.cs
+++ b/Morphic.Server/Billing/PromoCode.cs
@@ -65,6 +65,11 @@ namespace Morphic.Server.Billing
         public string? ValidForPlan { get; set; }
         public string? ValidForEmail { get; set; }
 
+        [JsonPropertyName("duration")]
+        public string Duration { get; set; } = null!;
+        [JsonPropertyName("duration_months")]
+        public long? DurationMonths { get; set; }
+
         /// <summary>Determines if the coupon is valid for an email address</summary>
         public bool IsEmailAllowed(string? email)
         {

--- a/Morphic.Server/Billing/StripePaymentProcessor.cs
+++ b/Morphic.Server/Billing/StripePaymentProcessor.cs
@@ -278,7 +278,9 @@ namespace Morphic.Server.Billing
                 Expired = promo.ExpiresAt < DateTime.UtcNow,
                 Active = promo.Active && promo.Coupon.Valid,
                 ValidForPlan = plan,
-                ValidForEmail = email
+                ValidForEmail = email,
+                Duration = promo.Coupon.Duration,
+                DurationMonths = promo.Coupon.DurationInMonths
             };
 
             return coupon;


### PR DESCRIPTION
Adding the coupon duration, so the front-end knows what to say.


Required by https://github.com/raisingthefloor/morphic-community-webapp/pull/205